### PR TITLE
Rename internal property to remove any possible confusion with RawRepresentable.

### DIFF
--- a/ImgFlo/Client.swift
+++ b/ImgFlo/Client.swift
@@ -49,9 +49,9 @@ public struct Client {
         let graphNameWithFormat: String
 
         if let format = derivedFormat {
-            graphNameWithFormat = graph.rawValue + "." + format.lowercaseString
+            graphNameWithFormat = graph.pathComponent + "." + format.lowercaseString
         } else {
-            graphNameWithFormat = graph.rawValue
+            graphNameWithFormat = graph.pathComponent
         }
         
         guard let token = "\(graphNameWithFormat)?\(query)\(secret)".MD5 else {

--- a/ImgFlo/Graph.swift
+++ b/ImgFlo/Graph.swift
@@ -19,7 +19,7 @@ public enum Graph {
     case MotionBlur(width: Int?, height: Int?, length: Double, angle: Double, brightness: Double, contrast: Double, strength: DecimalFraction)
     case Passthrough(width: Int?, height: Int?)
     
-    var rawValue: String {
+    var pathComponent: String {
         switch self {
         case .Canvas: return "canvas"
         case .Crop: return "crop"


### PR DESCRIPTION
Since enums can conform to `RawRepresentable` which has a `rawValue` property, this was renamed to `pathComponent` which is also a better description.
