### PR TITLE
Update to use no-op graph for GIFs.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "soffes/Crypto" ~> 0.1.0
+github "soffes/Crypto" "a37c87d2bd795892cafbb1a1a3f2727247e8c2c3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "soffes/Crypto" "v0.1.0"
+github "soffes/Crypto" "a37c87d2bd795892cafbb1a1a3f2727247e8c2c3"
 github "Quick/Nimble" "v2.0.0-rc.3"
 github "Quick/Quick" "v0.6.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "soffes/Crypto" "v0.1.0"
-github "Quick/Nimble" "811003c1e556d6fedd12a6e8b81da235a7479aca"
+github "Quick/Nimble" "v2.0.0-rc.3"
 github "Quick/Quick" "v0.6.0"

--- a/ImgFlo/Client.swift
+++ b/ImgFlo/Client.swift
@@ -25,12 +25,16 @@ public struct Client {
             return URL
         }
         
-        guard URL.pathExtension != "gif" else {
-            return URL
+        let input = NSURLQueryItem(name: "input", value: URLString)
+        let verifiedGraph: Graph
+        
+        if URL.pathExtension == "gif" {
+            verifiedGraph = .NoOp
+        } else {
+            verifiedGraph = graph
         }
         
-        let input = NSURLQueryItem(name: "input", value: URLString)
-        components.queryItems = [ input ] + graph.queryItems
+        components.queryItems = [ input ] + verifiedGraph.queryItems
         
         guard let query = components.percentEncodedQuery else {
             return .None
@@ -49,9 +53,9 @@ public struct Client {
         let graphNameWithFormat: String
 
         if let format = derivedFormat {
-            graphNameWithFormat = graph.pathComponent + "." + format.lowercaseString
+            graphNameWithFormat = verifiedGraph.pathComponent + "." + format.lowercaseString
         } else {
-            graphNameWithFormat = graph.pathComponent
+            graphNameWithFormat = verifiedGraph.pathComponent
         }
         
         guard let token = "\(graphNameWithFormat)?\(query)\(secret)".MD5 else {

--- a/ImgFlo/Graph.swift
+++ b/ImgFlo/Graph.swift
@@ -17,6 +17,7 @@ public enum Graph {
     case InstagramNashville(width: Int?, height: Int?)
     case InstagramXProII(width: Int?, height: Int?)
     case MotionBlur(width: Int?, height: Int?, length: Double, angle: Double, brightness: Double, contrast: Double, strength: DecimalFraction)
+    case NoOp
     case Passthrough(width: Int?, height: Int?)
     
     var pathComponent: String {
@@ -37,6 +38,7 @@ public enum Graph {
         case .InstagramNashville: return "insta_nashville"
         case .InstagramXProII: return "insta_xproii"
         case .MotionBlur: return "motionblur"
+        case .NoOp: return "noop"
         case .Passthrough: return "passthrough"
         }
     }
@@ -156,6 +158,8 @@ public enum Graph {
                 "contrast": contrast,
                 "strength": strength.value
             ]
+        case NoOp:
+            params = [:]
         case let .Passthrough(width, height):
             params = [
                 "width": width,

--- a/ImgFlo/Graph.swift
+++ b/ImgFlo/Graph.swift
@@ -168,11 +168,8 @@ public enum Graph {
         }
         
         let reducedParams = params.reduce([NSURLQueryItem]()) { accum, elem in
-            if let value: AnyObject = elem.1 {
-                return accum  + [ NSURLQueryItem(name: elem.0, value: "\(value)") ]
-            } else {
-                return accum
-            }
+            guard let value: AnyObject = elem.1 else { return accum }
+            return accum  + [ NSURLQueryItem(name: elem.0, value: "\(value)") ]
         }
         
         return reducedParams.sort { $0.name < $1.name }

--- a/ImgFloTests/ClientSpec.swift
+++ b/ImgFloTests/ClientSpec.swift
@@ -118,12 +118,14 @@ class ClientSpec: QuickSpec {
             }
             
             context("with a .gif extension") {
-                it("should return the original URL") {
-                    let graph: Graph = .Passthrough(width: 720, height: nil)
+                it("should return a proxying URL with no-op graph") {
+                    let graph: Graph = .Passthrough(width: nil, height: nil)
                     let input = "http://www.reactiongifs.com/wp-content/uploads/2013/11/I-have-no-idea-what-I-am-doing.gif"
                     let URL = imgflo.getURL(graph, input)
                     
-                    expect(URL?.absoluteString).to(equal(input))
+                    let expected = "https://imgflo.herokuapp.com/graph/key/7a5c8e2c18cb5032f43b1b5348190404/noop.gif?input=http://www.reactiongifs.com/wp-content/uploads/2013/11/I-have-no-idea-what-I-am-doing.gif"
+                    
+                    expect(URL?.absoluteString).to(equal(expected))
                 }
             }
             


### PR DESCRIPTION
There is now support for processing gifs using the `noop` graph, which should be used even if a different graph is specified. These changes reflect that.

The resulting benefits are that images will now be cached, and also served over https which prevents mixed/insecure content warnings.

This also has a couple of incidental changes, the most significant being an update to the Crypto dependency to fix an issue on OS X.
